### PR TITLE
Refactor compare functions and update documentation

### DIFF
--- a/denofo/comparator/compare.py
+++ b/denofo/comparator/compare.py
@@ -13,6 +13,10 @@ def _turn_value_to_string(val: Any, model_name: str, field_name: str) -> str:
 
     :param val: The element to turn into a string.
     :type val: Any
+    :param model_name: The name of the model (necessary for correct indentation level).
+    :type model_name: str
+    :param field_name: The name of the field (necessary for correct indentation level).
+    :type field_name: str
     :return: The element as a string.
     :rtype: str
     """
@@ -52,9 +56,15 @@ def _get_output_string(
     """
     Get the comparison result as a string.
 
-    :param comparison: The comparison result.
+    :param comparison: The comparison input as preprocessed by :func:`denofo.utils.helpers.compare_two_models` .
     :type comparison: list[tuple]
-    :return: The comparison result as a string.
+    :param mode: The mode of comparison, either "similarities" or "differences".
+    :type mode: str
+    :param name1: The display name of the first comparison element.
+    :type name1: str
+    :param name2: The display name of the second comparison element.
+    :type name2: str
+    :return: The comparison result as a formatted string.
     :rtype: str
     """
     last_model = ""
@@ -138,10 +148,16 @@ def write_comparison(
     """
     Write the comparison result to the output file.
 
-    :param comparison: The comparison result.
+    :param comparison: The comparison input as preprocessed by :func:`denofo.utils.helpers.compare_two_models` .
     :type comparison: list[tuple]
+    :param mode: The mode of comparison, either "similarities" or "differences". Defaults to "differences".
+    :type mode: str
     :param output_path: The path to the output file. If None, the result is returned as a string.
     :type output_path: Path | None
+    :param name1: The display name of the first comparison element. Defaults to "dngf_1".
+    :type name1: str
+    :param name2: The display name of the second comparison element. Defaults to "dngf_2".
+    :type name2: str
     :return: The comparison result as a string if output_path is None, otherwise None.
     :rtype: str | None
     """

--- a/denofo/comparator/compare.py
+++ b/denofo/comparator/compare.py
@@ -1,42 +1,47 @@
 from pathlib import Path
 from enum import Enum
 from typing import Any
-from denofo.utils.constants import SUBMODELS, SUBMODEL_FIELDS, FIELDS_OF_LVL1_SUBMODELS
+from denofo.utils.constants import (
+    SUBMODELS,
+    INDENT_LVL_DICT,
+)
 
 
-def _turn_value_to_string(val: Any, sep_num: int = 2) -> str:
+def _turn_value_to_string(val: Any, model_name: str, field_name: str) -> str:
     """
     Turn an element into a string.
 
     :param val: The element to turn into a string.
     :type val: Any
-    :param sep_num: The number of separators.
-    :type sep_num: int
     :return: The element as a string.
     :rtype: str
     """
     val_str = ""
-    tab = "\t"
-    separator = "\n" + sep_num * tab
+    leading_tab_num = max(
+        INDENT_LVL_DICT.get(field_name, 0), INDENT_LVL_DICT.get(model_name, 0)
+    )
 
     if isinstance(val, dict):
-        val_str += separator.join(
+        val_str = "\n".join(
             [
-                f"{k}: {separator + tab if isinstance(v, dict) else ''}"
-                f"{separator + tab if isinstance(v, list) and len(v) > 1 else ''}"
-                f"{_turn_value_to_string(v, sep_num=sep_num + 1)}"
+                (
+                    f"{(leading_tab_num + 1) * '\t'}{k}:\n"
+                    f"{_turn_value_to_string(v, new_model, new_field)}"
+                )
                 for k, v in val.items()
                 if v is not None
+                and (new_model := k if k in SUBMODELS else model_name)
+                and (new_field := k if k not in SUBMODELS else field_name)
             ]
         )
     elif isinstance(val, (list, tuple, set)):
-        val_str += separator.join(
-            [_turn_value_to_string(e, sep_num=sep_num + 1) for e in val]
+        val_str = "\n".join(
+            [_turn_value_to_string(e, model_name, field_name) for e in val]
         )
     elif isinstance(val, Enum):
-        val_str += f"{val.value}"
+        val_str = f"{(leading_tab_num + 1) * '\t'}{val.value}"
     else:
-        val_str += f"{val}"
+        val_str = f"{(leading_tab_num + 1) * '\t'}{val}"
 
     return val_str
 
@@ -57,14 +62,13 @@ def _get_output_string(
     last_comparison_type = ""
     output_string = ""
     tab = "\t"
-    sep_num = 1
     passed_models = set()
 
     if mode == "similarities":
-        output_string += f"Identical values between {name1} and {name2}:\n"
+        output_string += f"Identical values between {name1} and {name2}:\n\n"
         compare_lst = [elem for elem in comparison if elem[0] == "same"]
     elif mode == "differences":
-        output_string += f"Differences between {name1} and {name2}:\n"
+        output_string += f"Differences between {name1} and {name2}:\n\n"
         compare_lst = [elem for elem in comparison if elem[0] != "same"]
 
     for elem in compare_lst:
@@ -75,62 +79,53 @@ def _get_output_string(
         val_lst = elem[3:]
 
         if model != last_model:
-            if model not in passed_models:
-                if model in SUBMODELS:
-                    if SUBMODEL_FIELDS[model] in FIELDS_OF_LVL1_SUBMODELS:
-                        sep_num = 1
-                    output_string += f"\n{sep_num * tab}{SUBMODEL_FIELDS[model]}:\n"
-                    sep_num += 1
-                else:
-                    output_string += f"\n{model}:\n"
-                    sep_num = 1
+            if model not in passed_models and model in SUBMODELS:
+                output_string += f"{INDENT_LVL_DICT[model] * '\t'}{model}:\n"
+                passed_models.add(model)
 
             last_model = model
             last_field = ""
             last_comparison_type = ""
 
         if field != last_field:
-            if field in FIELDS_OF_LVL1_SUBMODELS:
-                sep_num = 1
-            output_string += f"\n{sep_num * tab}{field}:\n"
+            output_string += f"{INDENT_LVL_DICT[field] * tab}{field}:\n"
             last_field = field
             last_comparison_type = ""
         if comparison_type != last_comparison_type:
             prefix_string = True
             last_comparison_type = comparison_type
 
-        vals = _turn_value_to_string(val_lst, sep_num=sep_num)
-        sep_num += 1
+        leading_tabs = (
+            max(INDENT_LVL_DICT.get(field, 0), INDENT_LVL_DICT.get(model, 0)) + 1
+        ) * tab
+        val_str = _turn_value_to_string(val_lst, model, field)
 
         if mode == "similarities":
             if comparison_type == "same":
-                output_string += f"{sep_num * tab}{vals}\n"
+                output_string += f"{val_str}\n"
         elif comparison_type == "diffval":
             prefix_string = (
-                f"\n{sep_num * tab}differing values in {name1} and {name2}:\n"
+                f"\n{leading_tabs}differing values in {name1} and {name2}:\n"
                 if prefix_string
                 else ""
             )
-            output_string += f"{prefix_string}{sep_num * tab}{vals}\n"
+            output_string += f"{prefix_string}{val_str}\n\n"
         elif comparison_type == "2not1":
             prefix_string = (
-                f"\n{sep_num * tab}values in {name2} but not in {name1}:\n"
+                f"\n{leading_tabs}values in {name2} but not in {name1}:\n"
                 if prefix_string
                 else ""
             )
-            output_string += f"{prefix_string}{sep_num * tab}{vals}\n"
+            output_string += f"{prefix_string}{val_str}\n\n"
         elif comparison_type == "1not2":
             prefix_string = (
-                f"\n{sep_num * tab}values in {name1} but not in {name2}:\n"
+                f"\n{leading_tabs}values in {name1} but not in {name2}:\n"
                 if prefix_string
                 else ""
             )
-            output_string += f"{prefix_string}{sep_num * tab}{vals}\n"
+            output_string += f"{prefix_string}{val_str}\n\n"
 
-        passed_models.add(model)
-        sep_num -= 1
-
-    return output_string
+    return output_string.replace("\n\n\n", "\n\n").strip()
 
 
 def write_comparison(

--- a/denofo/utils/constants.py
+++ b/denofo/utils/constants.py
@@ -107,9 +107,9 @@ FUNCS_TO_MODELS_DICT = {
 }
 
 SUBMODELS = {
+    "DeNovoGeneAnnotation",
     "AnnotGenome",
     "Transcriptome",
-    "TaxonID",
     "PhylogeneticTaxa",
     "HomologyFilter",
     "SyntenySearch",
@@ -118,30 +118,57 @@ SUBMODELS = {
     "TranslationalEvidence",
 }
 
-SUBMODEL_FIELDS = {
-    "AnnotGenome": "inputAnnotGenome",
-    "Transcriptome": "inputTranscriptome",
-    "TaxonID": "taxonID",
-    "PhylogeneticTaxa": "phylogeneticTaxa",
-    "HomologyFilter": "homologyFilter",
-    "SyntenySearch": "synteny",
-    "NonCodingHomologs": "nonCodingHomologs",
-    "EvolutionaryInformation": "evolutionaryInformation",
-    "TranslationalEvidence": "translationalEvidence",
-}
-
-FIELDS_OF_LVL1_SUBMODELS = {
-    "inputAnnotGenome",
-    "inputTranscriptome",
-    "phylogeneticTaxa",
-    "homologyFilter",
-    "nonCodingHomologs",
-    "evolutionaryInformation",
-    "translationalEvidence",
-}  # without taxonID and synteny, because these are second level submodels
-
 REPLACEMENTS = {
     "[": '["',
     "]": '"]',
     ",": '","',
+}
+
+INDENT_LVL_DICT = {
+    "DeNovoGeneAnnotation": 0,
+    "inputData": 1,
+    "inputAnnotGenome": 2,
+    "AnnotGenome": 3,
+    "annotGenomeChoice": 3,
+    "inputTranscriptome": 2,
+    "Transcriptome": 2,
+    "expressionLevel": 3,
+    "transContextChoice": 3,
+    "customGeneticContext": 3,
+    "transORFChoice": 3,
+    "customORF": 3,
+    "transcriptomeInfo": 3,
+    "customInputData": 2,
+    "nonCodingHomologs": 1,
+    "translationalEvidence": 1,
+    "taxonID": 2,
+    "TaxonID": 2,
+    "HomologyFilter": 1,
+    "homologyFilter": 1,
+    "PhylogeneticTaxa": 2,
+    "phylogeneticTaxa": 2,
+    "taxSpecificity": 3,
+    "taxID": 3,
+    "seqType": 2,
+    "customSeqType": 2,
+    "structuralSimilarity": 2,
+    "threshold": 2,
+    "customThreshold": 2,
+    "thresholdValue": 2,
+    "dataBase": 2,
+    "customDB": 2,
+    "NonCodingHomologs": 1,
+    "enablingMutations": 2,
+    "synteny": 2,
+    "SyntenySearch": 2,
+    "anchors": 3,
+    "customAnchor": 3,
+    "softwareSyntenySearch": 3,
+    "EvolutionaryInformation": 1,
+    "evolutionaryInformation": 1,
+    "selection": 2,
+    "TranslationalEvidence": 1,
+    "translationEvidence": 2,
+    "customTranslationEvidence": 2,
+    "studyURL": 1,
 }

--- a/tests/unit/test_compare.py
+++ b/tests/unit/test_compare.py
@@ -3,16 +3,20 @@ from denofo.comparator.compare import write_comparison
 from enum import Enum
 from denofo.comparator.compare import _turn_value_to_string
 
-
-# Import the functions to test
-
-# Monkey-patch the constants to avoid submodel complications in tests.
+# patch the constants to avoid submodel complications in tests.
 # These constants are otherwise imported from denofo.utils.constants.
 import denofo.comparator.compare as cmp_mod
 
-cmp_mod.SUBMODELS = []
-cmp_mod.SUBMODEL_FIELDS = {}
-cmp_mod.FIELDS_OF_LVL1_SUBMODELS = []
+cmp_mod.SUBMODELS = {"ModelA", "ModelB", "ModelC", "ModelX"}
+cmp_mod.INDENT_LVL_DICT = {
+    "ModelA": 1,
+    "ModelB": 1,
+    "ModelC": 1,
+    "ModelX": 1,
+    "fieldX": 2,
+    "fieldY": 2,
+    "fieldZ": 2,
+}
 
 
 def test_write_comparison_similarities():
@@ -30,8 +34,10 @@ def test_write_comparison_similarities():
     assert "fieldX:" in output
     assert "identical value" in output
     # Check that complex value is represented as string
-    assert "a: " in output
-    assert "b: " in output
+    assert "a:" in output
+    assert "1" in output
+    assert "b:" in output
+    assert "2" in output
 
 
 def test_write_comparison_differences():
@@ -85,5 +91,5 @@ def test_turn_value_to_string_enum_instance():
     class DummyEnum(Enum):
         VALUE = "dummy_value"
 
-    result = _turn_value_to_string(DummyEnum.VALUE)
-    assert result == "dummy_value"
+    result = _turn_value_to_string(DummyEnum.VALUE, "modelA", "fieldX")
+    assert result.strip() == "dummy_value"


### PR DESCRIPTION
- fix messy indentation formatting logic in compare.py
- fix indentation for "differing" values
- clearer code and indentation handling
- remove unnecessary constants and add one clearer new one as replacement
- update tests to handle new indentation and line break rules as well as new _turn_value_to_string() positional arguments
- update docs